### PR TITLE
Thuxuan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,54 @@
 [![Apache License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![dbt logo and version](https://img.shields.io/static/v1?logo=dbt&label=dbt-version&message=1.x&color=orange)
 
-# Claim Preprocessing
+# Claims Preprocessing
 
 Check out the [Claims Preprocessing Data Model](https://docs.google.com/spreadsheets/d/1NuMEhcx6D6MSyZEQ6yk0LWU0HLvaeVma8S-5zhOnbcE/edit#gid=1120321085)
 
 Check out our [Docs](http://thetuvaproject.com/)
 
-Claims pre-processing enhances data to make it useful for analytics.  It is done by:
+Claims preprocessing enhances medical claims data to make it useful for analytics.  It is done by:
 
-- Assigning encounter types to individual claim lines based on the bill type code and or revenue code of institutional claims and the place of service code of professional claims.
-- Grouping individual claims into encounters (this involves logic to, for example, merge claims with overlapping dates or adjacent dates into a single inpatient stay).
+- Assigning encounter types to individual claim lines based on the bill type code and or revenue code of institutional claims 
+and the place of service code of professional claims.
+- Grouping individual claims into encounters (this involves logic to, for example, merge claims with overlapping dates or 
+adjacent dates into a single inpatient stay).
 - Crosswalk professional claims to institutional encounters.
 
 
 ## Pre-requisites
 1. You have claims data (CCLF, SAF, commercial) in a data warehouse mapped to the Tuva input layer (reference Google sheet linked above)
     - The claim input layer is at a claim line level and each claim id and claim line number is unique
-    - The eligibility file is unique at the month/year grain per patient
+    - The eligibility file is unique at the month/year grain per patient and payor
     - Revenue code is 4 digits in length
 2. You have [dbt](https://www.getdbt.com/) installed and configured (i.e. connected to your data warehouse)
 
 [Here](https://docs.getdbt.com/dbt-cli/installation) are instructions for installing dbt.
 
-## Configuration
-Execute the following steps to load all seed files, build all data marts, and run all data quality tests in your data warehouse:
+## Getting Started
+Complete the following steps to configure the package to run in your environment.
 
 1. [Clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) this repo to your local machine or environment
 2. Create a database called 'tuva' in your data warehouse
-    - note: this is where data from the project will be generated
-3. Create source data tables in your data warehouse
-    - note: these tables must match table names and column names exactly as in [source.yml](models/source.yml)
-4. Configure [dbt_project.yml](/dbt_project.yml)
-    - profile: set to 'tuva' by default - change this to an active profile in the profile.yml file that connects to your data warehouse
-    - vars: configure source_name, source database name, and source schema name
-5. Run project
-    1. Navigate to the project directory in the command line
-    2. Execute "dbt build" to create all tables/views in your data warehouse
+    - Note: this is optional, see step 4 for further detail
+3. Configure [dbt_project.yml](/dbt_project.yml)
+    - Fill in vars (variables):
+        - source_name - description of the dataset feeding this project
+        - input_database - database where sources feeding this project are stored
+        - input_schema - schema where sources feeding this project is stored
+        - output_database - database where output of this project should be written.  
+        We suggest using the Tuva database but any database will work.
+        - output_schema - name of the schema where output of this project should be written
+4. Review [sources.yml](/sources.yml)
+The table names listed are the same as in the Tuva data model (linked above).  If you decided to rename these tables:
+    - Update table names in sources.yml
+    - Update table name in medical_claim and eligibility jinja function
+
+5. Execute `dbt build` to load seed files, run models, and perform tests.  
+    - Note: The pipeline will stops
 
 ## Contributions
-Have an opinion on the mappings? Notice any bugs when installing 
-and running the package? If so, we highly encourage and welcome contributions to this package! 
+Have an opinion on the mappings? Notice any bugs when installing and running the package? 
+If so, we highly encourage and welcome contributions! 
 
 Join the conversation on [Slack](https://tuvahealth.slack.com/ssb/redirect#/shared-invite/email)!  We'd love to hear from you on the #claims-preprocessing channel.
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,13 +7,13 @@ config-version: 2
 profile: 'default'
 
 vars:
-  source_name:                      # configuration required
+  source_name: cclf                     # configuration required
                                         # name describing the dataset feeding this project
 
-  input_database:           # configuration required
+  input_database: medicare_cclf         # configuration required
                                         # name of the database where sources feeding this project are stored
 
-  input_schema:             # configuration required
+  input_schema: claims_input            # configuration required
                                         # name of the schema where sources feeding this project is stored
 
   output_database: tuva                 # configuration required
@@ -21,6 +21,7 @@ vars:
 
   output_schema: claims_preprocessing   # configuration required
                                         # name of the schema where output of this project should be written
+                                        
   medical_claim: "{{ source(var('source_name'),'medical_claim') }}"
   eligibility: "{{ source(var('source_name'),'eligibility') }}"
 

--- a/models/transformation/config/encounter_inst_stage.yml
+++ b/models/transformation/config/encounter_inst_stage.yml
@@ -1,0 +1,13 @@
+version: 2
+
+models:
+    - name: encounter_inst_stage
+      description: Encounter level data elements for institutional claims
+      config:
+        schema: "{{ var('source_name')}}_{{ var('output_schema')}}"
+      columns:
+        - name: encounter_id
+          description: Unique identifier
+          tests:
+            - unique
+            - not_null

--- a/models/transformation/config/encounter_prof_stage.yml
+++ b/models/transformation/config/encounter_prof_stage.yml
@@ -1,0 +1,13 @@
+version: 2
+
+models:
+    - name: encounter_prof_stage
+      description: Encounter level data elements for profession claims
+      config:
+        schema: "{{ var('source_name')}}_{{ var('output_schema')}}"
+      columns:
+        - name: encounter_id
+          description: Unique identifier
+          tests:
+            - unique
+            - not_null

--- a/models/transformation/encounter_inst_stage.sql
+++ b/models/transformation/encounter_inst_stage.sql
@@ -1,0 +1,64 @@
+-------------------------------------------------------------------------------
+-- Author       Thu Xuan Vu
+-- Created      June 2022
+-- Purpose      Populate encounter level details.
+-------------------------------------------------------------------------------
+-- Modification History
+--
+-------------------------------------------------------------------------------
+
+with encounter_combined as(
+  select 
+    encounter_id
+    ,min(claim_start_date) as encounter_start_date
+    ,max(claim_end_date) as encounter_end_date
+    ,sum(cast(paid_amount as numeric(38,2))) as paid_amount
+    ,sum(charge_amount) as charge_amount
+  from {{ ref('medical_claim_stage')}} mc
+  group by
+      encounter_id
+)
+, encounter_stage as(
+  select
+    mc.encounter_id
+    ,mc.patient_id
+    ,mc.encounter_type
+    ,mc.admit_source_code
+    ,mc.admit_source_description
+    ,mc.admit_type_code
+    ,mc.admit_type_description
+    ,mc.discharge_disposition_code
+    ,mc.discharge_disposition_description
+    ,mc.rendering_npi as physician_npi
+    ,cast(null as varchar) as location
+    ,mc.facility_npi
+    ,mc.ms_drg
+    ,cast('{{ var('source_name')}}' as varchar) as data_source
+    ,row_number() over (partition by mc.encounter_id order by mc.claim_line_number, mc.claim_start_date) as row_sequence_first
+    ,row_number() over (partition by mc.encounter_id order by mc.claim_line_number, mc.claim_end_date) as row_sequence_last
+  from {{ ref('medical_claim_stage')}} mc
+  where claim_type = 'I'
+)
+
+select distinct
+    cast(s.encounter_id as varchar) as encounter_id
+    ,cast(s.patient_id as varchar) as patient_id
+    ,cast(s.encounter_type as varchar) as encounter_type
+    ,cast(c.encounter_start_date as date) as encounter_start_date
+    ,cast(c.encounter_end_date as date) as encounter_end_date
+    ,cast(first_value(s.admit_source_code) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_source_code
+    ,cast(first_value(s.admit_source_description) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_source_description
+    ,cast(first_value(s.admit_type_code) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_type_code
+    ,cast(first_value(s.admit_type_description) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_type_description
+    ,cast(last_value(s.discharge_disposition_code) over(partition by s.encounter_id order by s.row_sequence_last rows between unbounded preceding and unbounded following) as varchar) as discharge_disposition_code
+    ,cast(last_value(s.discharge_disposition_description) over(partition by s.encounter_id order by s.row_sequence_last rows between unbounded preceding and unbounded following) as varchar) as discharge_disposition_description
+    ,cast(first_value(s.physician_npi) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as physician_npi
+    ,cast(s.location as varchar) as location
+    ,cast(first_value(s.facility_npi) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as facility_npi
+    ,cast(first_value(s.ms_drg) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as ms_drg
+    ,cast(c.paid_amount as numeric(38,2)) as paid_amount
+    ,cast(c.charge_amount as numeric(38,2)) as charge_amount
+    ,cast(s.data_source as varchar) as data_source
+from encounter_stage s
+inner join encounter_combined c
+	on s.encounter_id = c.encounter_id

--- a/models/transformation/encounter_prof_stage.sql
+++ b/models/transformation/encounter_prof_stage.sql
@@ -1,0 +1,64 @@
+-------------------------------------------------------------------------------
+-- Author       Thu Xuan Vu
+-- Created      June 2022
+-- Purpose      Populate encounter level details.
+-------------------------------------------------------------------------------
+-- Modification History
+--
+-------------------------------------------------------------------------------
+
+with encounter_combined as(
+  select 
+    encounter_id
+    ,min(claim_start_date) as encounter_start_date
+    ,max(claim_end_date) as encounter_end_date
+    ,sum(cast(paid_amount as numeric(38,2))) as paid_amount
+    ,sum(charge_amount) as charge_amount
+  from {{ ref('medical_claim_stage')}} mc
+  group by
+      encounter_id
+)
+, encounter_stage as(
+  select
+    mc.encounter_id
+    ,mc.patient_id
+    ,mc.encounter_type
+    ,mc.admit_source_code
+    ,mc.admit_source_description
+    ,mc.admit_type_code
+    ,mc.admit_type_description
+    ,mc.discharge_disposition_code
+    ,mc.discharge_disposition_description
+    ,mc.rendering_npi as physician_npi
+    ,cast(null as varchar) as location
+    ,mc.facility_npi
+    ,mc.ms_drg
+    ,cast('{{ var('source_name')}}' as varchar) as data_source
+    ,row_number() over (partition by mc.encounter_id order by mc.claim_line_number, mc.claim_start_date) as row_sequence_first
+    ,row_number() over (partition by mc.encounter_id order by mc.claim_line_number, mc.claim_end_date) as row_sequence_last
+  from {{ ref('medical_claim_stage')}} mc
+  where claim_type in ('P','DME')
+)
+
+select distinct
+    cast(s.encounter_id as varchar) as encounter_id
+    ,cast(s.patient_id as varchar) as patient_id
+    ,cast(s.encounter_type as varchar) as encounter_type
+    ,cast(c.encounter_start_date as date) as encounter_start_date
+    ,cast(c.encounter_end_date as date) as encounter_end_date
+    ,cast(first_value(s.admit_source_code) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_source_code
+    ,cast(first_value(s.admit_source_description) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_source_description
+    ,cast(first_value(s.admit_type_code) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_type_code
+    ,cast(first_value(s.admit_type_description) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as admit_type_description
+    ,cast(last_value(s.discharge_disposition_code) over(partition by s.encounter_id order by s.row_sequence_last rows between unbounded preceding and unbounded following) as varchar) as discharge_disposition_code
+    ,cast(last_value(s.discharge_disposition_description) over(partition by s.encounter_id order by s.row_sequence_last rows between unbounded preceding and unbounded following) as varchar) as discharge_disposition_description
+    ,cast(first_value(s.physician_npi) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as physician_npi
+    ,cast(s.location as varchar) as location
+    ,cast(first_value(s.facility_npi) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as facility_npi
+    ,cast(first_value(s.ms_drg) over(partition by s.encounter_id order by s.row_sequence_first rows between unbounded preceding and unbounded following) as varchar) as ms_drg
+    ,cast(c.paid_amount as numeric(38,2)) as paid_amount
+    ,cast(c.charge_amount as numeric(38,2)) as charge_amount
+    ,cast(s.data_source as varchar) as data_source
+from encounter_stage s
+inner join encounter_combined c
+	on s.encounter_id = c.encounter_id


### PR DESCRIPTION
## Describe your changes
Split encounter into two queries, one to handle institutional and another to handle professional.  This is necessary to prioritize institutional data elements over professional.  Previously, this would cause nulls in fields like discharge disposition and admit type (UB 04 fields) even though it was as acute inpatient encounter.  The logic was using a combination of inst and prof claims to find the first and last values within an encounter and sometimes the first and last value would be a prof claim even though there are inst claims mixed in.

Fixes bug #34 

## Testing
- Took a count before and after change of NULL discharge dispositions for institutional claims.  After fix, no fields were null
- Ran dbt build after all changes made.  No test errors and dollar validation matches up.


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows style guidelines
- [x] I have commented my code as necessary 
- [x] I have made corresponding changes to documentation
- [x] My code runs without errors
- [x] I have implemented primary key tests
- [x] Every model has a corresponding yml file

