### PR TITLE
added logic to use empty pharmacy claim table if variable is set, inc…

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'claims_preprocessing'
-version: '0.1.5'
+version: '0.1.6'
 config-version: 2
 
 profile: 'default'

--- a/models/claims_preprocessing__prescription.sql
+++ b/models/claims_preprocessing__prescription.sql
@@ -1,5 +1,12 @@
 {{ config(enabled=var('claims_preprocessing_enabled',var('tuva_packages_enabled',True))) }}
 
+{% if builtins.var('pharmacy_claim')|lower == "none" %}
+{% set source_exists = false %}
+{% else %}
+{% set source_exists = true %}
+{% endif -%}
+
+{% if source_exists %}
 select
     cast(claim_id as {{ dbt.type_string() }}) as claim_id
     , cast(claim_line_number as {{ dbt.type_string() }}) as claim_line_number
@@ -17,3 +24,29 @@ select
     , cast(allowed_amount as numeric ) as allowed_amount
     , cast(data_source as {{ dbt.type_string() }}) as data_source
 from {{ var('pharmacy_claim')}} m
+
+{% else %}
+
+{% if execute %}
+{{- log("pharmacy_claim soruce does not exist, using empty table.", info=true) -}}
+{% endif %}
+select
+    cast(null as {{ dbt.type_string() }}) as claim_id
+    , cast(null as {{ dbt.type_string() }}) as claim_line_number
+    , cast(null as {{ dbt.type_string() }}) as patient_id
+    , cast(null as {{ dbt.type_string() }}) as member_id
+    , cast(null as {{ dbt.type_string() }}) as prescribing_provider_npi
+    , cast(null as {{ dbt.type_string() }}) as dispensing_provider_npi
+    , cast(null as date ) as dispensing_date
+    , cast(null as {{ dbt.type_string() }}) as ndc_code
+    , cast(null as int ) as quantity
+    , cast(null as int ) as days_supply
+    , cast(null as int) as refills
+    , cast(null as date ) as paid_date
+    , cast(null as numeric ) as paid_amount
+    , cast(null as numeric ) as allowed_amount
+    , cast(null as {{ dbt.type_string() }}) as data_source
+    limit 0
+
+{%- endif %}
+


### PR DESCRIPTION

## Describe your changes
Added logic to use an empty pharmacy claim table if the pharmacy_claim variable has the value of none

## How has this been tested?
Ran on Snowflake, Redshift, and Bigquery with the new toggle set

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.

## Checklist before requesting a review
- [x]  I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [x]  I have tested my code by running `dbt build` in **Snowflake**
- [x]  I have tested my code by running `dbt build` in **Redshift**
- [x]  I have tested my code by running `dbt build` in **Redshift**
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have updated dbt docs by running `dbt docs generate` and copying the appropriate files to the `docs/` path
- [x]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](https://media.giphy.com/media/3orieROOWsTTFdhUbe/giphy.gif)

## Loom link
https://www.loom.com/share/9545a6820d0f4560bd61c8d672b5a163